### PR TITLE
Dbus notifications

### DIFF
--- a/configuration.py
+++ b/configuration.py
@@ -36,6 +36,8 @@ class Configuration(object):
                 'server':               ['Local','localhost','6600',''],
                 'musicPath':            '~/Music',
                 'scBookmarkFile':       '~/Music/shoutcast-bookmarks.xml',
+                'showNotification':     False,
+                'notificationTimeout':  0,
                 'oneLinePlaylist':      False,
                 'showShoutcast':        False,
                 'tabsIndex':            0,
@@ -120,8 +122,14 @@ class Configuration(object):
         self.setup.setWindowTitle('Pythagora settings')
         self.setup.setWindowIcon(QIcon('Pythagora.png'))
         self.setup.setAttribute(Qt.WA_QuitOnClose, False)
-        # Hide options for functions not yet implemented.
-        self.setup.showNotificationWidget.setVisible(False)
+
+        # Hide dbus options if module not present
+        try:
+            import dbus
+        except ImportError:
+            self.setup.showNotificationWidget.setVisible(False)
+        self.setup.showNotification.setChecked(self.showNotification)
+        self.setup.notificationTimeout.setValue(self.notificationTimeout)
 
         self.setup.musicPath.setText(self.musicPath)
         self.setup.scBookmarkFile.setText(self.scBookmarkFile)

--- a/configuration.py
+++ b/configuration.py
@@ -188,6 +188,8 @@ class Configuration(object):
         else:
             print 'debug: no server selected'
             self.server = None
+        self.showNotification = self.setup.showNotification.isChecked()
+        self.notificationTimeout = self.setup.notificationTimeout.value()
         self.musicPath = unicode(self.setup.musicPath.text())
         self.__checkDir("Music",self.musicPath)
         self.scBookmarkFile = unicode(self.setup.scBookmarkFile.text())

--- a/mpdlibrary.py
+++ b/mpdlibrary.py
@@ -210,7 +210,7 @@ def _getSongAttr(song, attrs):
                 return title
     for attr in attrs:
         if attr in song:
-            return song[attr].strip()
+            return song[attr].strip() if isinstance(song[attr], str) else song[attr]
 
 def _getTextField(value):
     if getattr(value, '__iter__', False):

--- a/pythagora
+++ b/pythagora
@@ -21,6 +21,7 @@ from PyQt4.QtGui import QApplication, QWidget, QKeySequence
 
 import sys
 import signal
+import os
 
 import mpdthreaded as mpd
 import playControls
@@ -250,6 +251,31 @@ class Update:
         # Set the progress timer up.
         self.timer = QTimer()
         self.view.connect(self.timer, SIGNAL("timeout()"), self.progress)
+        # DBus notifications
+        if self.config.showNotification:
+            try:
+                import dbus
+            except ImportError, e:
+                self.config.showNotification = False
+                return
+            self.notificationId = dbus.UInt32(0)
+            self.appName = unicode(QApplication.applicationName().toUtf8())
+            # app_icon url is correct, doesn't display in Plasma though
+            self.appIcon = 'file://'+os.path.abspath(MainWindow.DATA_DIR+'icons/Pythagora.png')
+            self.notificationSummary = '%s, now playing:' % self.appName
+            self.notificationHints = dbus.Dictionary(
+                {'suppress-sound':  True,
+                 'desktop-entry':   'pythagora',
+                 'image_path':      ''},
+                'sv')
+            try:
+                self.dbusNotification = dbus.SessionBus().get_object(
+                    'org.freedesktop.Notifications',
+                    '/org/freedesktop/Notifications',
+                    'org.freedesktop.Notifications')
+            except dbus.DBusException, e:
+                self.config.showNotification = False
+                print 'debug: error using dbus - %s' % e
 
     def update(self, changes, status):
         self.timer.start(1000)
@@ -295,6 +321,12 @@ class Update:
         self.mixer(status)
 
     def _currentsong(self, currentsong):
+        if (mpdlibrary.isStream(currentsong) and
+            mpdlibrary.songTitle(self.lastSong) ==
+            mpdlibrary.songTitle(currentsong) and
+            mpdlibrary.songArtist(self.lastSong) ==
+            mpdlibrary.songArtist(currentsong)):
+            return # stream metadata hasn't changed, so don't update
         self.setSongLabel(
                 mpdlibrary.songTitle(currentsong),
                 mpdlibrary.songArtist(currentsong),
@@ -337,6 +369,23 @@ class Update:
         label = '<br>'.join((item for item in (title, artist, album, station) if item))
         icon = self.view.currentList.playingItem().iconPath
         self.view.trayIcon.setToolTip(icon, label)
+        self.setNotification(icon, label)
+
+    def setNotification(self, icon, label):
+        if not self.config.showNotification:
+            return
+        iconPath = 'file://%s' % icon if icon else self.appIcon
+        self.notificationHints.update({'image_path':iconPath})
+        # Show notification
+        self.notificationId = self.dbusNotification.Notify(
+            self.appName,                           #app_name
+            self.notificationId,                    #replaces_id
+            self.appIcon,                           #app_icon
+            self.notificationSummary,               #summary
+            label,                                  #body
+            [''],                                   #actions
+            self.notificationHints,                 #hints
+            self.config.notificationTimeout * 1000) #timeout
 
     def setProgress(self, cs, ss=None):
         ''' Moves the progress indicator to the correct position,


### PR DESCRIPTION
Here's the notifications implemented based on your current code. 

However, there is a bug: 
`CurrentPlaylistForm.playingItem()` returns the item of the previous song, so the icon is incorrect. From what I can see, it's because the `Update._currentsong()` slot is executed before the `CurrentPlaylistForm.setPlaying()` slot from the `currentSong` signal. 

I can see two solutions:
1. Connect `CurrentPlaylistForm.setPlaying()` to a different signal that is emitted right at the beginning of `Update._currentsong()`, so it is executed first; or
2. Get the item using it's position - the song's 'pos' attribute should always match it's index in the playlist QListWidget. So something like `CurrentPlaylistForm.itemAt(index)` that returns the item. This would be useful in future too imho, eg for a song info plugin.

Didn't know which approach you would prefer, or if there's a better way - so left it as is.

Cheers :)
