### PR TITLE
Icecast plugin

### DIFF
--- a/MainWindow.py
+++ b/MainWindow.py
@@ -165,22 +165,27 @@ class View(QMainWindow, auxilia.Actions):
         loadedPlugins = []
         for plugin in plugins.allPlugins:
             loadedPlugins.append(plugin.getWidget(self, self.mpdclient, self.config))
-        if len(loadedPlugins) > len(self.config.tabOrder):
-            newPlugins = [plugin for plugin in loadedPlugins if plugin.moduleName not in self.config.tabOrder]
-        else:
-            newPlugins = []
-        for name in self.config.tabOrder:
+        loadedPluginNames = set([plugin.moduleName for plugin in loadedPlugins])
+        tabOrderSet = set(self.config.tabOrder)
+        removedPlugins = tabOrderSet - loadedPluginNames
+        newPlugins = loadedPluginNames - tabOrderSet
+        tabOrder = self.config.tabOrder
+        if len(removedPlugins) > 0:
+            for pluginName in removedPlugins:
+                tabOrder.remove(pluginName)
+        for name in tabOrder:
             for plugin in loadedPlugins:
                 if plugin.moduleName == name:
                     self.tabs.addTab(plugin, auxilia.PIcon(plugin.moduleIcon), plugin.moduleName)
                     break
         if len(newPlugins) > 0:
-            order = self.config.tabOrder
+            newPlugins = [plugin for plugin in loadedPlugins 
+                          if plugin.moduleName in newPlugins]
             for plugin in newPlugins:
                 self.tabs.addTab(plugin, auxilia.PIcon(plugin.moduleIcon),
                                  plugin.moduleName)
-                order.append(plugin.moduleName)
-            self.config.tabOrder = order
+                tabOrder.append(plugin.moduleName)
+        self.config.tabOrder = tabOrder
 
     def shutdown(self):
         self.shuttingDown = True

--- a/MainWindow.py
+++ b/MainWindow.py
@@ -165,11 +165,22 @@ class View(QMainWindow, auxilia.Actions):
         loadedPlugins = []
         for plugin in plugins.allPlugins:
             loadedPlugins.append(plugin.getWidget(self, self.mpdclient, self.config))
+        if len(loadedPlugins) > len(self.config.tabOrder):
+            newPlugins = [plugin for plugin in loadedPlugins if plugin.moduleName not in self.config.tabOrder]
+        else:
+            newPlugins = []
         for name in self.config.tabOrder:
             for plugin in loadedPlugins:
                 if plugin.moduleName == name:
                     self.tabs.addTab(plugin, auxilia.PIcon(plugin.moduleIcon), plugin.moduleName)
                     break
+        if len(newPlugins) > 0:
+            order = self.config.tabOrder
+            for plugin in newPlugins:
+                self.tabs.addTab(plugin, auxilia.PIcon(plugin.moduleIcon),
+                                 plugin.moduleName)
+                order.append(plugin.moduleName)
+            self.config.tabOrder = order
 
     def shutdown(self):
         self.shuttingDown = True

--- a/mpdlibrary.py
+++ b/mpdlibrary.py
@@ -210,7 +210,7 @@ def _getSongAttr(song, attrs):
                 return title
     for attr in attrs:
         if attr in song:
-            return song[attr].strip()
+            return song[attr].strip() if isinstance(song[attr], str) else song[attr]
 
 def _getTextField(value):
     if getattr(value, '__iter__', False):

--- a/plugins/IcecastForm.py
+++ b/plugins/IcecastForm.py
@@ -1,0 +1,120 @@
+# -*- coding: utf-8 -*
+#-------------------------------------------------------------------------------
+# Copyright 2010 B. Kroon <bart@tarmack.eu>.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#-------------------------------------------------------------------------------
+from PyQt4.QtCore import SIGNAL, QUrl, QEvent
+from PyQt4.QtGui import QVBoxLayout
+from PyQt4.QtWebKit import QWebView, QWebPage
+try:
+    from lxml import etree
+except ImportError:
+    import xml.etree.ElementTree as etree
+import StringIO
+
+import re
+import httplib
+
+import PluginBase
+
+HOMEURL = "http://dir.xiph.org/"
+TUNEIN = "dir.xiph.org"
+TUNEINFORMAT = re.compile(r'/listen/\d+/listen\.(m3u|xspf)$')
+
+class IcecastForm(PluginBase.PluginBase):
+    '''
+    '''
+    moduleName = 'I&cecast'
+    moduleIcon = "network-workgroup"
+
+    def load(self):
+        pass
+
+    def event(self, event):
+        if event.type() == QEvent.Paint:
+            if not hasattr(self, 'webView'):
+                self._load()
+                self.event = super(IcecastForm, self).event
+        return False
+
+    def _load(self):
+        self.webView = QWebView(self)
+        self.webPage = self.webView.page()
+
+        self.layout = QVBoxLayout(self)
+        self.layout.addWidget(self.webView)
+        self.webView.load(QUrl(HOMEURL))
+        self.webPage.setLinkDelegationPolicy(QWebPage.DelegateExternalLinks)
+        self.connect(self.webPage, SIGNAL('linkClicked(const QUrl&)'), self._processLink)
+
+    def _processLink(self, url):
+        urlString = url.toString()
+        urlMatch = TUNEINFORMAT.match(urlString)
+        if urlMatch is not None:
+            self._playStation(urlString, urlMatch)
+        else:
+            self.webView.load(url)
+            self.webView.show()
+
+    def _playStation(self, url, match):
+        path = match.group(0)
+        format = match.group(1)
+        data = self._retreivePlaylist(path)
+        if format == 'xspf':
+            adrlist = self.parseXSPF(data)
+        else:
+            adrlist = self.parseM3U(data)
+        self.mpdclient.send('command_list_ok_begin')
+        try:
+            for address in adrlist:
+                self.mpdclient.send('add', (address,))
+        finally:
+            self.mpdclient.send('command_list_end')
+
+    def _retreivePlaylist(self, path):
+        conn = httplib.HTTPConnection(TUNEIN)
+        conn.request("GET", path)
+        resp = conn.getresponse()
+        if resp.status == 200:
+            return resp.read()
+        else:
+            raise httplib.HTTPException('Got bad status code.')
+
+    def _parseXSPF(self, data):
+        ''' XSPF spec: http://www.xspf.org/xspf-v1.html
+            Currently we only want the location URLs, so that
+            is all we parse for.
+        '''
+        xml = etree.parse(StringIO(data))
+        root = xml.getroot()
+        locations = root.findall('{http://xspf.org/ns/0/}location')
+        adrlist = [adr.text for adr in locations if adr.text.startswith('http')]
+        if not adrlist:
+             raise httplib.HTTPException('Encountered error during parsing of the playlist.')
+        return adrlist
+    
+    def _parseM3U(self, data):
+        adrlist = []
+        data = data.split('\n')
+        while data:
+            line = data.pop(0)
+            if line.startswith('http://'):
+                adrlist.append(value)
+        if not adrlist:
+             raise httplib.HTTPException('Encountered error during parsing of the playlist.')
+        return adrlist
+
+
+def getWidget(view, mpdclient, config):
+    return IcecastForm(view, mpdclient, config)


### PR DESCRIPTION
I've shamelessly ripped off your tremendously great idea for a Shoutcast plugin to create an Icecast plugin for the xiph.org directory. It parses m3u and XSPF playlist files, instead of pls. Using the website directly gets around the 1000 station limit if using the downloadable station list, so having easy access to the whole lot makes me happy. :)

There's also a small bit of code for MainWindow that detects new plugins, so they can be automatically added to the tabOrder setting (and thus displayed).

[![Pythagora Icecast plugin](http://ompldr.org/vN3piaA/pythagora-icecast.png)](http://ompldr.org/vN3piaA/pythagora-icecast.png)
