### PR TITLE
Adding support for disc number for better sorting in album songs list

### DIFF
--- a/mpdlibrary.py
+++ b/mpdlibrary.py
@@ -161,7 +161,8 @@ class Library:
             return 'directory'
 
 def _sortAlbumSongs(x, y):
-    return cmp(int(x.track), int(y.track))
+    # Sorting album songs by disc number, then by track number
+    return cmp(int(x.disc), int(y.disc)) or cmp(int(x.track), int(y.track))
 
 def _getField(song, fields, alt):
     value = alt
@@ -364,6 +365,16 @@ class Track(Text):
         return int(track)
 
 
+class DiscNumber(Text):
+    def __int__(self):
+        disc_number = str(self)
+        if '/' in disc_number:
+            disc_number = disc_number.split('/', 1)[0]
+        if disc_number == '':
+            disc_number = 0
+        return int(disc_number)
+
+
 class Song(dict, LibraryObject):
     def __init__(self, value, library):
         dict.__init__(self, value)
@@ -412,6 +423,9 @@ class Song(dict, LibraryObject):
                     self._library)
         elif item == 'track':
             return Track(self._getAttr('track') or '',
+                    self._library)
+        elif item == 'disc':
+            return DiscNumber(self._getAttr('disc') or '',
                     self._library)
         elif item == 'station':
             # Only applicable when the Song object


### PR DESCRIPTION
Hello,

I began to use Pythagora a few days ago and found it lacked support of the disc number tag. The problem was that the order of the songs in the album songs list was a bit of a mess when it comes to a multi-disc album.

I managed to get what I wanted by adding the `DiscNumber` class the same way you did the `Track` one.
The rest of this little job was to complete the `_sortAlbumSongs` comparison method.

I hope this contribution will be useful, especially to enjoy listing (and then listening to) albums such as Pink Floyd's _The Wall_, The Who's _Quadrophenia_, Genesis' _The Lamb Lies Down On Broadway_, and much more!

Yours,
Mathias
